### PR TITLE
removed ScheduledRunsStatus

### DIFF
--- a/src/pages/mapper/RepoConfigs.js
+++ b/src/pages/mapper/RepoConfigs.js
@@ -35,7 +35,6 @@ import EditMappings from "./actions/EditMappings";
 import ImportConfig from "./actions/ImportConfig";
 import RepoSkeleton from "../../components/skeleton/Skeleton";
 import ActiveSiteConfigInfo from "../configs/Site/ActiveSiteConfigInfo";
-import ScheduledRunsStatus from "../configs/Schedules/ScheduledRunsStatus";
 
 
 
@@ -106,7 +105,6 @@ const RepoConfigs = () =>{
                                         <Divider/>
 
                                         <DataExtraction baseRepo={baselookup} />
-                                        <ScheduledRunsStatus />
 
                                     </MainCard>
                             </MainCard>


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Removed unused ScheduledRunsStatus component from the RepoConfigs page layout